### PR TITLE
Routablize codenotify content

### DIFF
--- a/CODENOTIFY
+++ b/CODENOTIFY
@@ -1,1 +1,0 @@
-*/** @nicksnyder

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codenotify
 
-Codenotify is a tool that analyzes the files changed in one or more git commits and emits the list of people who have subscribed to be notified when those files change. File subscribers are defined in [CODENOTIFY](#codenotify) files.
+Codenotify is a tool that analyzes the files changed in one or more git commits and emits the list of people who have subscribed to be notified when those files change. File subscribers are defined in [CODEPROS](#codepros) files.
 
 Codenotify can be run on the command line, or as a GitHub Action.
 
@@ -19,7 +19,7 @@ a1b2c3...HEAD
 
 When run as a GitHub Action, Codenotify will post a comment that mentions people who have subscribed to files changed in that pull request.
 
-> Notifying subscribers in [CODENOTIFY](https://github.com/sourcegraph/codenotify) files for diff a1b2c3...d4e5f6.
+> Notifying subscribers in [CODEPROS](https://github.com/routablehq/sourcegraph/codenotify) files for diff a1b2c3...d4e5f6.
 >
 > | Notify | File(s)                |
 > | ------ | ---------------------- |
@@ -48,15 +48,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: sourcegraph/codenotify@v0.4
         env:
-          # secrets.GITHUB_TOKEN is available by default, but it won't allow CODENOTIFY to mention GitHub teams.
-          # If you want CODENOTIFY to be able to mention teams, then you need to create a personal access token
+          # secrets.GITHUB_TOKEN is available by default, but it won't allow CODEPROS to mention GitHub teams.
+          # If you want CODEPROS to be able to mention teams, then you need to create a personal access token
           # (https://github.com/settings/tokens) with scopes: repo, read:org.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-## CODENOTIFY files
+## CODEPROS files
 
-CODENOTIFY files contain rules that define who gets notified when files change.
+CODEPROS files contain rules that define who gets notified when files change.
 
 Here is an example:
 
@@ -66,7 +66,7 @@ Here is an example:
 # Empty lines are ignored.
 
 # Each non-comment/non-empty line is a file pattern followed by one or more subscribers separated by whitespace.
-# File patterns are relative to the directory of the CODENOTIFY file that they are defined in.
+# File patterns are relative to the directory of the CODEPROS file that they are defined in.
 # Absolute paths that start with a slash will not match anything.
 # Example:
 # Both @alice and @bob subscribe to file.go.
@@ -80,12 +80,12 @@ file.go     @alice @bob
 file.go @alice
 file.go @bob
 
-# A rule can match files in subdirectories of the CODENOTIFY file's directory.
+# A rule can match files in subdirectories of the CODEPROS file's directory.
 # Example:
 subdir/file.go @alice
-# Alternatively, you can place a CODENOTIFY file in the subdirectory.
+# Alternatively, you can place a CODEPROS file in the subdirectory.
 
-# A rule can not match files in parent directories of the CODENOTIFY file.
+# A rule can not match files in parent directories of the CODEPROS file.
 # Example: @wont-match won't be notified of changes to file.go.
 ../file.go @wont-match
 
@@ -128,9 +128,9 @@ The [OWNERS](https://chromium.googlesource.com/chromium/src/+/master/docs/code_r
 
 Codenotify makes a different set of tradeoffs:
 
-1. There can be a CODENOTIFY file in any directory.
+1. There can be a CODEPROS file in any directory.
 1. Rules are additive and do not have precedence.
-1. CODENOTIFY is focused on notifications, not code review. The GitHub Action mentions subscribers in a comment instead of adding them to the "Reviewers" list of a PR.
+1. Codenotify is focused on notifications, not code review. The GitHub Action mentions subscribers in a comment instead of adding them to the "Reviewers" list of a PR.
 
 Codenotify can be used in conjunction with, or as a replacement for CODEOWNERS.
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sourcegraph/codenotify
+module github.com/routablehq/codenotify
 
 go 1.15

--- a/main.go
+++ b/main.go
@@ -394,16 +394,17 @@ func (o *options) writeNotifications(w io.Writer, notifs map[string][]string) er
 		return nil
 	case "markdown":
 		fmt.Fprint(w, markdownCommentTitle)
-		fmt.Fprintf(w, "Notifying subscribers in [CODENOTIFY](https://github.com/sourcegraph/codenotify) files for diff %s...%s.\n\n", o.baseRef, o.headRef)
 		if len(notifs) == 0 {
 			fmt.Fprintln(w, "No notifications.")
 		} else {
-			fmt.Fprint(w, "| Notify | File(s) |\n")
-			fmt.Fprint(w, "|-|-|\n")
+			fmt.Fprintln(w, "👔 Code pros! Mind taking a look at this PR?")
+
+			codeProNames := []string{}
 			for _, sub := range subs {
-				files := notifs[sub]
-				fmt.Fprintf(w, "| %s | %s |\n", sub, strings.Join(files, "<br>"))
+				codeProNames = append(codeProNames, sub)
 			}
+
+			fmt.Fprintf(w, "cc: %s", strings.Join(codeProNames, " "))
 		}
 		return nil
 	default:
@@ -442,7 +443,7 @@ func subscribers(fs FS, path string) ([]string, error) {
 	parts := strings.Split(path, string(os.PathSeparator))
 	for i := range parts {
 		base := filepath.Join(parts[:i]...)
-		rulefilepath := filepath.Join(base, "CODENOTIFY")
+		rulefilepath := filepath.Join(base, "CODEPROS")
 
 		rulefile, err := fs.Open(rulefilepath)
 		if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,7 @@ func TestMain(t *testing.T) {
 				headRef: "$headRef",
 			},
 			files: map[string]string{
-				"CODENOTIFY": "**/*.md @markdown",
+				"CODEPROS": "**/*.md @markdown",
 				"file.md":    "",
 			},
 			changedFiles: []string{
@@ -146,8 +146,7 @@ func TestWriteNotifications(t *testing.T) {
 			notifs: nil,
 			output: []string{
 				"<!-- codenotify report -->",
-				"Notifying subscribers in [CODENOTIFY](https://github.com/sourcegraph/codenotify) files for diff a...b.",
-				"",
+				"👔 Code pros! Mind taking a look at this PR?"
 				"No notifications.",
 			},
 		},
@@ -177,12 +176,8 @@ func TestWriteNotifications(t *testing.T) {
 			},
 			output: []string{
 				"<!-- codenotify report -->",
-				"Notifying subscribers in [CODENOTIFY](https://github.com/sourcegraph/codenotify) files for diff a...b.",
-				"",
-				"| Notify | File(s) |",
-				"|-|-|",
-				"| @go | file.go<br>dir/file.go |",
-				"| @js | file.js<br>dir/file.js |",
+				"👔 Code pros! Mind taking a look at this PR?",
+                "cc: @go, @js"
 			},
 		},
 		{
@@ -250,7 +245,7 @@ func TestNotifications(t *testing.T) {
 		{
 			name: "no notifications",
 			fs: memfs{
-				"CODENOTIFY":      "nomatch.md @notify\n",
+				"CODEPROS":      "nomatch.md @notify\n",
 				"file.md":         "",
 				"dir/file.md":     "",
 				"dir/dir/file.md": "",
@@ -260,7 +255,7 @@ func TestNotifications(t *testing.T) {
 		{
 			name: "file.md",
 			fs: memfs{
-				"CODENOTIFY":      "file.md @notify\n",
+				"CODEPROS":      "file.md @notify\n",
 				"file.md":         "",
 				"dir/file.md":     "",
 				"dir/dir/file.md": "",
@@ -272,7 +267,7 @@ func TestNotifications(t *testing.T) {
 		{
 			name: "no leading slash",
 			fs: memfs{
-				"CODENOTIFY":      "/file.md @notify\n",
+				"CODEPROS":      "/file.md @notify\n",
 				"file.md":         "",
 				"dir/file.md":     "",
 				"dir/dir/file.md": "",
@@ -282,7 +277,7 @@ func TestNotifications(t *testing.T) {
 		{
 			name: "whitespace",
 			fs: memfs{
-				"CODENOTIFY":      "\n\nfile.md @notify\n\n",
+				"CODEPROS":      "\n\nfile.md @notify\n\n",
 				"file.md":         "",
 				"dir/file.md":     "",
 				"dir/dir/file.md": "",
@@ -294,7 +289,7 @@ func TestNotifications(t *testing.T) {
 		{
 			name: "comments",
 			fs: memfs{
-				"CODENOTIFY": "#comment\n" +
+				"CODEPROS": "#comment\n" +
 					"file.md @notify\n",
 				"file.md":         "",
 				"dir/file.md":     "",
@@ -307,19 +302,19 @@ func TestNotifications(t *testing.T) {
 		{
 			name: "*",
 			fs: memfs{
-				"CODENOTIFY":      "* @notify\n",
+				"CODEPROS":      "* @notify\n",
 				"file.md":         "",
 				"dir/file.md":     "",
 				"dir/dir/file.md": "",
 			},
 			notifications: map[string][]string{
-				"@notify": {"CODENOTIFY", "file.md"},
+				"@notify": {"CODEPROS", "file.md"},
 			},
 		},
 		{
 			name: "dir/*",
 			fs: memfs{
-				"CODENOTIFY":      "dir/* @notify\n",
+				"CODEPROS":      "dir/* @notify\n",
 				"file.md":         "",
 				"dir/file.md":     "",
 				"dir/dir/file.md": "",
@@ -331,31 +326,31 @@ func TestNotifications(t *testing.T) {
 		{
 			name: "**",
 			fs: memfs{
-				"CODENOTIFY":      "** @notify\n",
+				"CODEPROS":      "** @notify\n",
 				"file.md":         "",
 				"dir/file.md":     "",
 				"dir/dir/file.md": "",
 			},
 			notifications: map[string][]string{
-				"@notify": {"CODENOTIFY", "file.md", "dir/file.md", "dir/dir/file.md"},
+				"@notify": {"CODEPROS", "file.md", "dir/file.md", "dir/dir/file.md"},
 			},
 		},
 		{
 			name: "**/*", // same as **
 			fs: memfs{
-				"CODENOTIFY":      "**/* @notify\n",
+				"CODEPROS":      "**/* @notify\n",
 				"file.md":         "",
 				"dir/file.md":     "",
 				"dir/dir/file.md": "",
 			},
 			notifications: map[string][]string{
-				"@notify": {"CODENOTIFY", "file.md", "dir/file.md", "dir/dir/file.md"},
+				"@notify": {"CODEPROS", "file.md", "dir/file.md", "dir/dir/file.md"},
 			},
 		},
 		{
 			name: "**/file.md",
 			fs: memfs{
-				"CODENOTIFY":      "**/file.md @notify\n",
+				"CODEPROS":      "**/file.md @notify\n",
 				"file.md":         "",
 				"dir/file.md":     "",
 				"dir/dir/file.md": "",
@@ -367,7 +362,7 @@ func TestNotifications(t *testing.T) {
 		{
 			name: "dir/**",
 			fs: memfs{
-				"CODENOTIFY":      "dir/** @notify\n",
+				"CODEPROS":      "dir/** @notify\n",
 				"file.md":         "",
 				"dir/file.md":     "",
 				"dir/dir/file.md": "",
@@ -379,7 +374,7 @@ func TestNotifications(t *testing.T) {
 		{
 			name: "dir/", // same as "dir/**"
 			fs: memfs{
-				"CODENOTIFY":      "dir/ @notify\n",
+				"CODEPROS":      "dir/ @notify\n",
 				"file.md":         "",
 				"dir/file.md":     "",
 				"dir/dir/file.md": "",
@@ -391,7 +386,7 @@ func TestNotifications(t *testing.T) {
 		{
 			name: "dir/**/file.md",
 			fs: memfs{
-				"CODENOTIFY":      "dir/**/file.md @notify\n",
+				"CODEPROS":      "dir/**/file.md @notify\n",
 				"file.md":         "",
 				"dirfile.md":      "",
 				"dir/file.md":     "",
@@ -404,26 +399,26 @@ func TestNotifications(t *testing.T) {
 		{
 			name: "multiple subscribers",
 			fs: memfs{
-				"CODENOTIFY": "* @alice @bob\n",
+				"CODEPROS": "* @alice @bob\n",
 				"file.md":    "",
 			},
 			notifications: map[string][]string{
-				"@alice": {"CODENOTIFY", "file.md"},
-				"@bob":   {"CODENOTIFY", "file.md"},
+				"@alice": {"CODEPROS", "file.md"},
+				"@bob":   {"CODEPROS", "file.md"},
 			},
 		},
 		{
 			name: "..",
 			fs: memfs{
-				"dir/CODENOTIFY": "../* @alice @bob\n",
+				"dir/CODEPROS": "../* @alice @bob\n",
 				"file.md":        "",
 			},
 			notifications: nil,
 		},
 		{
-			name: "multiple CODENOTIFY",
+			name: "multiple CODEPROS",
 			fs: memfs{
-				"CODENOTIFY": "\n" +
+				"CODEPROS": "\n" +
 					"* @rootany\n" +
 					"*.go @rootgo\n" +
 					"*.js @rootjs\n" +
@@ -433,7 +428,7 @@ func TestNotifications(t *testing.T) {
 				"file.md": "",
 				"file.js": "",
 				"file.go": "",
-				"dir/CODENOTIFY": "\n" +
+				"dir/CODEPROS": "\n" +
 					"* @dir/any\n" +
 					"*.go @dir/go\n" +
 					"*.js @dir/js\n" +
@@ -443,7 +438,7 @@ func TestNotifications(t *testing.T) {
 				"dir/file.md": "",
 				"dir/file.go": "",
 				"dir/file.js": "",
-				"dir/dir/CODENOTIFY": "\n" +
+				"dir/dir/CODEPROS": "\n" +
 					"* @dir/dir/any\n" +
 					"*.go @dir/dir/go\n" +
 					"*.js @dir/dir/js\n" +
@@ -456,15 +451,15 @@ func TestNotifications(t *testing.T) {
 			},
 			notifications: map[string][]string{
 				"@all": {
-					"CODENOTIFY",
+					"CODEPROS",
 					"file.md",
 					"file.js",
 					"file.go",
-					"dir/CODENOTIFY",
+					"dir/CODEPROS",
 					"dir/file.md",
 					"dir/file.go",
 					"dir/file.js",
-					"dir/dir/CODENOTIFY",
+					"dir/dir/CODEPROS",
 					"dir/dir/file.md",
 					"dir/dir/file.go",
 					"dir/dir/file.js",
@@ -480,7 +475,7 @@ func TestNotifications(t *testing.T) {
 					"dir/dir/file.js",
 				},
 				"@rootany": {
-					"CODENOTIFY",
+					"CODEPROS",
 					"file.md",
 					"file.js",
 					"file.go",
@@ -492,11 +487,11 @@ func TestNotifications(t *testing.T) {
 					"file.js",
 				},
 				"@dir/all": {
-					"dir/CODENOTIFY",
+					"dir/CODEPROS",
 					"dir/file.md",
 					"dir/file.go",
 					"dir/file.js",
-					"dir/dir/CODENOTIFY",
+					"dir/dir/CODEPROS",
 					"dir/dir/file.md",
 					"dir/dir/file.go",
 					"dir/dir/file.js",
@@ -510,7 +505,7 @@ func TestNotifications(t *testing.T) {
 					"dir/dir/file.js",
 				},
 				"@dir/any": {
-					"dir/CODENOTIFY",
+					"dir/CODEPROS",
 					"dir/file.md",
 					"dir/file.js",
 					"dir/file.go",
@@ -522,7 +517,7 @@ func TestNotifications(t *testing.T) {
 					"dir/file.js",
 				},
 				"@dir/dir/all": {
-					"dir/dir/CODENOTIFY",
+					"dir/dir/CODEPROS",
 					"dir/dir/file.md",
 					"dir/dir/file.go",
 					"dir/dir/file.js",
@@ -534,7 +529,7 @@ func TestNotifications(t *testing.T) {
 					"dir/dir/file.js",
 				},
 				"@dir/dir/any": {
-					"dir/dir/CODENOTIFY",
+					"dir/dir/CODEPROS",
 					"dir/dir/file.md",
 					"dir/dir/file.js",
 					"dir/dir/file.go",


### PR DESCRIPTION
[codenotify's](https://github.com/sourcegraph/codenotify/blob/main/main.go#L397) content is cool, but we're cooler